### PR TITLE
Fixed #44

### DIFF
--- a/src/main/java/hunternif/mc/atlas/client/TextureSet.java
+++ b/src/main/java/hunternif/mc/atlas/client/TextureSet.java
@@ -198,7 +198,7 @@ public class TextureSet implements Comparable<TextureSet> {
 	static {
 		stitchMutually(PLAINS, SUNFLOWERS);
 		WATER.stitchTo(SHORE, ROCK_SHORE, SWAMP);
-		LAVA.stitchTo(SHORE, ROCK_SHORE, LAVA_SHORE);
+		LAVA.stitchTo(LAVA_SHORE);
 		SWAMP.stitchTo(SWAMP_HILLS);
 		SNOW.stitchTo(SNOW_PINES, SNOW_HILLS, ICE_SPIKES, SNOW_PINES_HILLS);
 		SNOW_PINES.stitchTo(SNOW, SNOW_HILLS, ICE_SPIKES, SNOW_PINES_HILLS);


### PR DESCRIPTION
Quick change to fix #44 

Sets LAVA to only stitch to LAVA_SHORE, which makes lava pools look like this (left is ocean, right is a small river):
![current](https://cloud.githubusercontent.com/assets/5993218/8052052/27d65ce6-0e38-11e5-8cc9-37de195b719f.png)

For the sake of rigor, I also tested letting LAVA stitch to LAVA_SHORE and WATER, which looks like this:
![possible](https://cloud.githubusercontent.com/assets/5993218/8052054/2a67a9a6-0e38-11e5-938c-0812b43520bb.png)

The former looks weird when you have a flood of lava in the middle of the ocean, because it mistakenly shows up on the map with a ring of land and a pit filled with lava. The latter is a little awkward, but more accurately represents lava directly touching the water. The former version is in this commit and I think it looks best.