### PR TITLE
[Incomplete] Friendly Biome IDs

### DIFF
--- a/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
+++ b/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
@@ -7,8 +7,10 @@ import hunternif.mc.atlas.util.AbstractJSONConfig;
 import hunternif.mc.atlas.util.Log;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.registries.ForgeRegistry;
 
 import java.io.File;
 import java.util.Map.Entry;
@@ -58,16 +60,7 @@ public class BiomeTextureConfig extends AbstractJSONConfig<BiomeTextureMap> {
 				biomeID = Integer.parseInt(key);
 			} catch(NumberFormatException e) {
 				// If it is not an integer, attempt to find the biome ID assuming it is a resource location
-				ResourceLocation biomeResourceLocation;
-
-				if (key.contains(":")) {
-					String[] biomeStringSplit = key.split(":");
-					biomeResourceLocation = new ResourceLocation(biomeStringSplit[0], biomeStringSplit[1]);
-				} else {
-					biomeResourceLocation = new ResourceLocation(key);
-				}
-
-				Biome biome = Biome.REGISTRY.getObject(biomeResourceLocation);
+				Biome biome = ForgeRegistries.BIOMES.getValue(new ResourceLocation(key));
 
 				if (biome == null) {
 					Log.warn("Biome ID is invalid, skipping entry");
@@ -110,7 +103,8 @@ public class BiomeTextureConfig extends AbstractJSONConfig<BiomeTextureMap> {
 			// Only save biomes 0-256 in this config.
 			// The rest goes into ExtTileTextureConfig
 			if (biomeID >= 0 && biomeID < 256) {
-				String key = Biome.REGISTRY.getObjectById(biomeID).getRegistryName().toString();
+				Biome biome = ((ForgeRegistry<Biome>) ForgeRegistries.BIOMES).getValue(biomeID);
+				String key = biome.getRegistryName().toString();
 				json.addProperty(key, data.textureMap.get(biomeID).name);
 			}
 		}

--- a/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
+++ b/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
@@ -110,7 +110,8 @@ public class BiomeTextureConfig extends AbstractJSONConfig<BiomeTextureMap> {
 			// Only save biomes 0-256 in this config.
 			// The rest goes into ExtTileTextureConfig
 			if (biomeID >= 0 && biomeID < 256) {
-				json.addProperty(String.valueOf(biomeID), data.textureMap.get(biomeID).name);
+				String key = Biome.REGISTRY.getObjectById(biomeID).getRegistryName().toString();
+				json.addProperty(key, data.textureMap.get(biomeID).name);
 			}
 		}
 	}

--- a/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
+++ b/src/main/java/hunternif/mc/atlas/client/BiomeTextureConfig.java
@@ -97,15 +97,15 @@ public class BiomeTextureConfig extends AbstractJSONConfig<BiomeTextureMap> {
 	@Override
 	protected void saveData(JsonObject json, BiomeTextureMap data) {
 		// Sort keys (biome IDs) numerically:
-		Queue<Integer> queue = new PriorityQueue<>(data.textureMap.keySet());
+		Queue<Biome> queue = new PriorityQueue<>(data.textureMap.keySet());
 		while (!queue.isEmpty()) {
-			int biomeID = queue.poll();
+			Biome biome = queue.poll();
+			int biomeID = Biome.getIdForBiome(biome);
 			// Only save biomes 0-256 in this config.
 			// The rest goes into ExtTileTextureConfig
 			if (biomeID >= 0 && biomeID < 256) {
-				Biome biome = ((ForgeRegistry<Biome>) ForgeRegistries.BIOMES).getValue(biomeID);
 				String key = biome.getRegistryName().toString();
-				json.addProperty(key, data.textureMap.get(biomeID).name);
+				json.addProperty(key, data.textureMap.get(biome).name);
 			}
 		}
 	}

--- a/src/main/java/hunternif/mc/atlas/client/BiomeTextureMap.java
+++ b/src/main/java/hunternif/mc/atlas/client/BiomeTextureMap.java
@@ -1,6 +1,7 @@
 package hunternif.mc.atlas.client;
 
 import hunternif.mc.atlas.core.Tile;
+import hunternif.mc.atlas.util.CustomFormatter;
 import hunternif.mc.atlas.util.Log;
 import hunternif.mc.atlas.util.SaveData;
 import net.minecraft.util.ResourceLocation;
@@ -36,16 +37,22 @@ public class BiomeTextureMap extends SaveData {
 
 	/** Assign texture set to biome. */
 	public void setTexture(int biomeID, TextureSet textureSet) {
+		Biome biome = Biome.getBiomeForId(biomeID);
+
+		if (biome == null) {
+			return;
+		}
+
 		if (textureSet == null) {
-			if (textureMap.remove(Biome.getBiomeForId(biomeID)) != null) {
-				Log.warn("Removing old texture for biome %s", biomeID);
+			if (textureMap.remove(biome) != null) {
+				Log.warn("Removing old texture for biome %s", CustomFormatter.getRegistryString(biome));
 				if (biomeID >= 0 && biomeID < 256) {
 					markDirty();
 				}
 			}
 			return;
 		}
-		TextureSet previous = textureMap.put(Biome.getBiomeForId(biomeID), textureSet);
+		TextureSet previous = textureMap.put(biome, textureSet);
 		if (biomeID >= 0 && biomeID < 256) {
 			// The config only concerns itself with biomes 0-256.
 			// If the old texture set is equal to the new one (i.e. has equal name
@@ -53,7 +60,7 @@ public class BiomeTextureMap extends SaveData {
 			if (previous == null) {
 				markDirty();
 			} else if (!previous.equals(textureSet)) {
-				Log.warn("Overwriting texture set for biome %d", biomeID);
+				Log.warn("Overwriting texture set for biome %s", CustomFormatter.getRegistryString(biome));
 				markDirty();
 			}
 		}
@@ -62,12 +69,13 @@ public class BiomeTextureMap extends SaveData {
 	/** Find the most appropriate standard texture set depending on
 	 * BiomeDictionary types. */
 	private void autoRegister(int biomeID) {
+		Biome biome = Biome.getBiomeForId(biomeID);
 		if (biomeID < 0 || biomeID >= 256) {
-			Log.warn("Biome ID %d is out of range. Auto-registering default texture set", biomeID);
+			Log.warn("Biome ID %s is out of range. Auto-registering default texture set",
+					biome == null ? biomeID : CustomFormatter.getRegistryString(biome));
 			setTexture(biomeID, defaultTexture);
 			return;
 		}
-		Biome biome = Biome.getBiomeForId(biomeID);
 		if (biome == null) {
 			Log.warn("Biome ID %d is null. Auto-registering default texture set", biomeID);
 			setTexture(biomeID, defaultTexture);
@@ -205,7 +213,8 @@ public class BiomeTextureMap extends SaveData {
 		} else {
 			setTexture(biomeID, defaultTexture);
 		}
-		Log.info("Auto-registered standard texture set for biome %d", biomeID);
+		Log.info("Auto-registered standard texture set for biome %s",
+				CustomFormatter.getRegistryString(biome));
 	}
 
 	/** Auto-registers the biome ID if it is not registered. */

--- a/src/main/java/hunternif/mc/atlas/client/BiomeTextureMap.java
+++ b/src/main/java/hunternif/mc/atlas/client/BiomeTextureMap.java
@@ -30,14 +30,14 @@ public class BiomeTextureMap extends SaveData {
 	}
 
 	/** This map allows keys other than the 256 biome IDs to use for special tiles. */
-	final Map<Integer, TextureSet> textureMap = new HashMap<>();
+	final Map<Biome, TextureSet> textureMap = new HashMap<>();
 
 	public static final TextureSet defaultTexture = PLAINS;
 
 	/** Assign texture set to biome. */
 	public void setTexture(int biomeID, TextureSet textureSet) {
 		if (textureSet == null) {
-			if (textureMap.remove(biomeID) != null) {
+			if (textureMap.remove(Biome.getBiomeForId(biomeID)) != null) {
 				Log.warn("Removing old texture for biome %s", biomeID);
 				if (biomeID >= 0 && biomeID < 256) {
 					markDirty();
@@ -45,7 +45,7 @@ public class BiomeTextureMap extends SaveData {
 			}
 			return;
 		}
-		TextureSet previous = textureMap.put(biomeID, textureSet);
+		TextureSet previous = textureMap.put(Biome.getBiomeForId(biomeID), textureSet);
 		if (biomeID >= 0 && biomeID < 256) {
 			// The config only concerns itself with biomes 0-256.
 			// If the old texture set is equal to the new one (i.e. has equal name
@@ -217,14 +217,14 @@ public class BiomeTextureMap extends SaveData {
 	}
 
 	public boolean isRegistered(int biomeID) {
-		return textureMap.containsKey(biomeID);
+		return textureMap.containsKey(Biome.getBiomeForId(biomeID));
 	}
 
 	/** If unknown biome, auto-registers a texture set. If null, returns default set. */
 	public TextureSet getTextureSet(Tile tile) {
 		if (tile == null) return defaultTexture;
 		checkRegistration(tile.biomeID);
-		return textureMap.get(tile.biomeID);
+		return textureMap.get(Biome.getBiomeForId(tile.biomeID));
 	}
 
 	public ResourceLocation getTexture(Tile tile) {
@@ -237,7 +237,7 @@ public class BiomeTextureMap extends SaveData {
 
 	public List<ResourceLocation> getAllTextures() {
 		List<ResourceLocation> list = new ArrayList<>(textureMap.size());
-		for (Entry<Integer, TextureSet> entry : textureMap.entrySet()) {
+		for (Entry<Biome, TextureSet> entry : textureMap.entrySet()) {
 			list.addAll(Arrays.asList(entry.getValue().textures));
 		}
 		return list;

--- a/src/main/java/hunternif/mc/atlas/util/CustomFormatter.java
+++ b/src/main/java/hunternif/mc/atlas/util/CustomFormatter.java
@@ -1,0 +1,9 @@
+package hunternif.mc.atlas.util;
+
+import java.util.Objects;
+
+public class CustomFormatter {
+	public static String getRegistryString(net.minecraftforge.registries.IForgeRegistryEntry.Impl<?> entry) {
+		return Objects.requireNonNull(entry.getRegistryName()).toString();
+	}
+}


### PR DESCRIPTION
For #159

This adds support for referencing a biome using its resource location string, rather than the numerical id of the biome. Using id caused issues when adding a new mod that adds biomes, as IDs would be different between an existing world and a new world (just like the issues with item ids).

I've kept support in for using an id, but when the file is ever saved, it will over-write them with the resource location.