### PR TITLE
Watchers should ignore irrelevant MapGenStructureData tags (#168)

### DIFF
--- a/src/main/java/hunternif/mc/atlas/ext/watcher/WatcherPos.java
+++ b/src/main/java/hunternif/mc/atlas/ext/watcher/WatcherPos.java
@@ -2,7 +2,12 @@ package hunternif.mc.atlas.ext.watcher;
 
 import net.minecraft.util.math.BlockPos;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class WatcherPos {
+
+    public static final Pattern POS_PATTERN = Pattern.compile("\\[([-\\d]+),([-\\d]+)\\]");
 
     private final int x;
     private final int z;
@@ -18,12 +23,12 @@ public class WatcherPos {
 
     // format = [x, y]
     public WatcherPos(String coords) {
-        String[] coordSplit = coords.substring(1, coords.length() - 1).split(",");
-        if (coordSplit.length != 2)
+        Matcher matcher = POS_PATTERN.matcher(coords);
+        if (!matcher.matches())
             throw new IllegalArgumentException("Improper coordinate format provided: " + coords);
 
-        this.x = Integer.parseInt(coordSplit[0].trim());
-        this.z = Integer.parseInt(coordSplit[1].trim());
+        this.x = Integer.parseInt(matcher.group(1));
+        this.z = Integer.parseInt(matcher.group(2));
     }
 
     public int getX() {

--- a/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherFortress.java
+++ b/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherFortress.java
@@ -78,6 +78,9 @@ public class StructureWatcherFortress implements IStructureWatcher {
         Set<Pair<WatcherPos, String>> visits = Sets.newHashSet();
         Set<String> tagSet = structureTag.getKeySet();
         for (String coords : tagSet) {
+            if (!WatcherPos.POS_PATTERN.matcher(coords).matches())
+                continue; // Some other kind of data got stuffed in here. It's irrelevant to us
+
             WatcherPos pos = new WatcherPos(coords);
             if (!visited.contains(pos)) {
                 NBTTagCompound tag = structureTag.getCompoundTag(coords);

--- a/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherGeneric.java
+++ b/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherGeneric.java
@@ -74,6 +74,9 @@ public class StructureWatcherGeneric implements IStructureWatcher {
         Set<Pair<WatcherPos, String>> visits = Sets.newHashSet();
         Set<String> tagSet = structureTag.getKeySet();
         for (String coords : tagSet) {
+            if (!WatcherPos.POS_PATTERN.matcher(coords).matches())
+                continue; // Some other kind of data got stuffed in here. It's irrelevant to us
+
             WatcherPos pos = new WatcherPos(coords);
             if (!visited.contains(pos)) {
                 NBTTagCompound tag = structureTag.getCompoundTag(coords);

--- a/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherVillage.java
+++ b/src/main/java/hunternif/mc/atlas/ext/watcher/impl/StructureWatcherVillage.java
@@ -119,6 +119,9 @@ public class StructureWatcherVillage implements IStructureWatcher {
         Set<String> tagSet = structureTag.getKeySet();
         Set<Pair<WatcherPos, String>> visits = Sets.newHashSet();
         for (String coords : tagSet) {
+            if (!WatcherPos.POS_PATTERN.matcher(coords).matches())
+                continue; // Some other kind of data got stuffed in here. It's irrelevant to us
+
             WatcherPos pos = new WatcherPos(coords);
             if (!visited.contains(pos)) {
                 NBTTagCompound tag = structureTag.getCompoundTag(coords);


### PR DESCRIPTION
It seems that some mod is modifying this tag for their own purposes, so we should ignore anything not formatted as a coordinate.

This isn't actually tested to solve the crash because I don't know how to properly reproduce it, but *theoretically* it should stop the `DeletedStructures` tag from matching.