### PR TITLE
save atlas image to screenshots folder instead of invoking file chooser

### DIFF
--- a/src/main/java/hunternif/mc/atlas/client/TextureSet.java
+++ b/src/main/java/hunternif/mc/atlas/client/TextureSet.java
@@ -272,7 +272,7 @@ public class TextureSet implements Comparable<TextureSet> {
 	
 	/** Add other texture sets that this texture set will be stitched to
 	 * (but the opposite may be false, in case of asymmetric stitching.) */
-    private TextureSet stitchTo(TextureSet... textureSets) {
+	public TextureSet stitchTo(TextureSet... textureSets) {
 		Collections.addAll(stitchTo, textureSets);
 		return this;
 	}
@@ -285,12 +285,12 @@ public class TextureSet implements Comparable<TextureSet> {
 		return this;
 	}
 	
-	private TextureSet stitchToHorizontal(TextureSet... textureSets) {
+	public TextureSet stitchToHorizontal(TextureSet... textureSets) {
 		this.anisotropicStitching = true;
 		Collections.addAll(stitchToHorizontal, textureSets);
 		return this;
 	}
-	private TextureSet stitchToVertical(TextureSet... textureSets) {
+	public TextureSet stitchToVertical(TextureSet... textureSets) {
 		this.anisotropicStitching = true;
 		Collections.addAll(stitchToVertical, textureSets);
 		return this;

--- a/src/main/java/hunternif/mc/atlas/client/TextureSet.java
+++ b/src/main/java/hunternif/mc/atlas/client/TextureSet.java
@@ -272,7 +272,7 @@ public class TextureSet implements Comparable<TextureSet> {
 	
 	/** Add other texture sets that this texture set will be stitched to
 	 * (but the opposite may be false, in case of asymmetric stitching.) */
-	public TextureSet stitchTo(TextureSet... textureSets) {
+    private TextureSet stitchTo(TextureSet... textureSets) {
 		Collections.addAll(stitchTo, textureSets);
 		return this;
 	}
@@ -285,12 +285,12 @@ public class TextureSet implements Comparable<TextureSet> {
 		return this;
 	}
 	
-	public TextureSet stitchToHorizontal(TextureSet... textureSets) {
+	private TextureSet stitchToHorizontal(TextureSet... textureSets) {
 		this.anisotropicStitching = true;
 		Collections.addAll(stitchToHorizontal, textureSets);
 		return this;
 	}
-	public TextureSet stitchToVertical(TextureSet... textureSets) {
+	private TextureSet stitchToVertical(TextureSet... textureSets) {
 		this.anisotropicStitching = true;
 		Collections.addAll(stitchToVertical, textureSets);
 		return this;

--- a/src/main/java/hunternif/mc/atlas/client/gui/GuiAtlas.java
+++ b/src/main/java/hunternif/mc/atlas/client/gui/GuiAtlas.java
@@ -34,7 +34,10 @@ import org.lwjgl.opengl.GL11;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 public class GuiAtlas extends GuiComponent {
@@ -50,6 +53,8 @@ public class GuiAtlas extends GuiComponent {
 	private static final int PLAYER_ICON_HEIGHT = 8;
 
 	public static final int MARKER_SIZE = 32;
+
+	private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
 
 	/** If the map scale goes below this value, the tiles will not scale down
 	 * visually, but will instead span greater area. */
@@ -408,7 +413,25 @@ public class GuiAtlas extends GuiComponent {
 		state.switchTo(EXPORTING_IMAGE);
 		// Default file name is "Atlas <N>.png"
 		ExportImageUtil.isExporting = true;
-		File file = ExportImageUtil.selectPngFileToSave("Atlas " + atlasID);
+		
+		String atlaspath = Minecraft.getMinecraft().mcDataDir+"/screenshots/";
+		String outputname = "atlas-"+ DATE_FORMAT.format(new Date()).toString();
+		int i = 1;
+		
+		File file;
+		
+		while (true) {
+			file = new File(atlaspath, outputname + (i == 1 ? "" : "_" + i) + ".png");
+			
+			if (!file.exists()) {
+				break;
+			}
+			
+			++i;
+		}
+		
+		
+		//File file = ExportImageUtil.selectPngFileToSave("Atlas " + atlasID);
 		if (file != null) {
 			try {
 				Log.info("Exporting image from Atlas #%d to file %s", atlasID, file.getAbsolutePath());

--- a/src/main/java/hunternif/mc/atlas/client/gui/GuiAtlas.java
+++ b/src/main/java/hunternif/mc/atlas/client/gui/GuiAtlas.java
@@ -414,24 +414,19 @@ public class GuiAtlas extends GuiComponent {
 		// Default file name is "Atlas <N>.png"
 		ExportImageUtil.isExporting = true;
 		
-		String atlaspath = Minecraft.getMinecraft().mcDataDir+"/screenshots/";
-		String outputname = "atlas-"+ DATE_FORMAT.format(new Date()).toString();
-		int i = 1;
-		
-		File file;
-		
-		while (true) {
-			file = new File(atlaspath, outputname + (i == 1 ? "" : "_" + i) + ".png");
-			
-			if (!file.exists()) {
-				break;
-			}
-			
-			++i;
+		File screenshot_folder = new File(Minecraft.getMinecraft().mcDataDir, "screenshots");
+		if(!screenshot_folder.isDirectory())
+		{
+			screenshot_folder.mkdir();
 		}
-		
-		
-		//File file = ExportImageUtil.selectPngFileToSave("Atlas " + atlasID);
+
+		String outputname = "atlas-" + DATE_FORMAT.format(new Date());
+
+		File file = new File(screenshot_folder, outputname + ".png");
+		for (int i = 1; file.exists(); i++) {
+			file = new File(screenshot_folder, outputname + "_" + i + ".png");
+		}
+
 		if (file != null) {
 			try {
 				Log.info("Exporting image from Atlas #%d to file %s", atlasID, file.getAbsolutePath());


### PR DESCRIPTION
So out of frustration over #84 (especially after getting my antique cities mod more or less ready for my server) I suddenly felt industrious, and made this change.

I more or less duplicated the vanilla logic for naming the file, just prepending "atlas" to the name.

I don't know if this is how you guys want it done, and I don't know if you guys want it to emit a message to chat the way vanilla does for screenshots (which gives a link so you can find the file easier), but this at least makes it possible to export an atlas in all the instances I've tried (including a heavily modded instance with ~280 mods)

I didn't completely remove the old code, just commented out a single method call. Basically, this was just proof-of-concept-also-I-want-maps-now, and I thought I'd share. :)