### PR TITLE
added config option to decrease log spam from visited markers & workaround for crash 215

### DIFF
--- a/src/main/java/hunternif/mc/atlas/SettingsConfig.java
+++ b/src/main/java/hunternif/mc/atlas/SettingsConfig.java
@@ -70,6 +70,8 @@ public class SettingsConfig {
         public boolean doScanRavines = true;
         @Config.Comment({"If true, map render time will be output."})
         public boolean debugRender = false;
+        @Config.Comment({"If true, to get more detailed data about visited marker "})
+        public boolean useExtendedVisitedMarkerLogging = true;
     }
 
     @SubscribeEvent

--- a/src/main/java/hunternif/mc/atlas/SettingsConfig.java
+++ b/src/main/java/hunternif/mc/atlas/SettingsConfig.java
@@ -70,7 +70,7 @@ public class SettingsConfig {
         public boolean doScanRavines = true;
         @Config.Comment({"If true, map render time will be output."})
         public boolean debugRender = false;
-        @Config.Comment({"If true, to get more detailed data about visited marker "})
+        @Config.Comment({"If false, you get only the count of markers for each dimension, instead of position for each marke in each dimension "})
         public boolean useExtendedVisitedMarkerLogging = true;
     }
 

--- a/src/main/java/hunternif/mc/atlas/ext/watcher/StructureWatcher.java
+++ b/src/main/java/hunternif/mc/atlas/ext/watcher/StructureWatcher.java
@@ -1,6 +1,8 @@
 package hunternif.mc.atlas.ext.watcher;
 
 import com.google.common.collect.Sets;
+
+import hunternif.mc.atlas.SettingsConfig;
 import hunternif.mc.atlas.util.Log;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -42,8 +44,14 @@ public class StructureWatcher {
                 NBTTagCompound structureData = watcher.getStructureData(world);
                 if (structureData != null) {
                     Set<Pair<WatcherPos, String>> visited = watcher.visitStructure(world, structureData);
-                    for (Pair<WatcherPos, String> visit : visited)
-                        Log.info("Visited %s in dimension %d at %s", visit.getRight(), world.provider.getDimension(), visit.getLeft().toString());
+                                        
+                    if (SettingsConfig.performance.useExtendedVisitedMarkerLogging) {
+                    	for (Pair<WatcherPos, String> visit : visited)
+                    		Log.info("Visited %s in dimension %d at %s", visit.getRight(), world.provider.getDimension(), visit.getLeft().toString());
+                    }
+                    else if(visited != null){
+                    	Log.info("Loaded %d Visited Markers for dimension %d", visited.size(), world.provider.getDimension());
+                    }
                 }
             }
     }


### PR DESCRIPTION
Added config option to not write out every visited Marker in Server log.
Default is "true" and keeps old behaviour, if set to "false" it just writes 1 line for each dimension with the amount of loaded visited markers instead of writing one line for each marker (spams log if you have a lot of them).

Greetings yotthani