### PR TITLE
Opening the map with hotkey crashes the game

### DIFF
--- a/src/main/java/hunternif/mc/impl/atlas/client/KeyHandler.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/KeyHandler.java
@@ -1,5 +1,6 @@
 package hunternif.mc.impl.atlas.client;
 
+import hunternif.mc.impl.atlas.AntiqueAtlasModClient;
 import hunternif.mc.impl.atlas.client.gui.GuiAtlas;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
@@ -34,9 +35,7 @@ public class KeyHandler {
             if (currentScreen instanceof GuiAtlas) {
                 currentScreen.closeScreen();
             } else {
-                GuiAtlas gui = new GuiAtlas();
-                gui.updateL18n();
-                client.displayGuiScreen(gui);
+                AntiqueAtlasModClient.openAtlasGUI();
             }
         }
     }


### PR DESCRIPTION
`GuiAtlas` requires a manual initialization via `prepareToOpen` before it could be showed. The code between Fabric and Forge versions seems diverged and some changes were only partly applied to the Forge version. A similar change to the Fabric version had been done in 1868c686fbea86899b2735127f251e7a886f85fd.

Fixes #330