### PR TITLE
Update 1.18-fabric to 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,9 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version       = 1.18.1
-yarn_mappings           = 1.18.1+build.4
-loader_version          = 0.12.12
-
+minecraft_version       = 1.18.2
+yarn_mappings           = 1.18.2+build.4
+loader_version          = 0.14.8
 # Mod Properties
 mod_version 			= 6.2.0-fabric
 maven_group 			= hunternif.mc.atlas
@@ -13,5 +12,5 @@ archives_base_name 		= antiqueatlas
 
 # Dependencies
 cloth_config_version	= 5.1.40
-fabric_version			= 0.44.0+1.18
+fabric_version          = 0.58.0+1.18.2
 mod_menu_version		= 2.0.14

--- a/src/main/java/hunternif/mc/impl/atlas/client/KeyHandler.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/KeyHandler.java
@@ -37,7 +37,7 @@ public class KeyHandler {
         if (bindings.get(KEY_ATLAS).wasPressed()) {
             Screen currentScreen = MinecraftClient.getInstance().currentScreen;
             if (currentScreen instanceof GuiAtlas) {
-                currentScreen.onClose();
+                currentScreen.close();
             } else {
                 AntiqueAtlasModClient.openAtlasGUI();
             }

--- a/src/main/java/hunternif/mc/impl/atlas/client/TileTextureMap.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/TileTextureMap.java
@@ -119,7 +119,7 @@ public class TileTextureMap {
                 setTexture(id, TextureSetMap.instance().getByName(AntiqueAtlasMod.id("mountains")));
                 break;
             case THEEND:
-                List<List<Supplier<PlacedFeature>>> features = biome.getGenerationSettings().getFeatures();
+                //List<List<Supplier<PlacedFeature>>> features = biome.getGenerationSettings().getFeatures();
                 boolean has_chorus_plant = true;
                 //features.stream().anyMatch(supplier -> supplier.stream().anyMatch(step -> step.get() == ConfiguredFeatures.CHORUS_PLANT));
                 if (has_chorus_plant) {

--- a/src/main/java/hunternif/mc/impl/atlas/client/gui/GuiAtlas.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/gui/GuiAtlas.java
@@ -532,7 +532,7 @@ public class GuiAtlas extends GuiComponent {
 
         // close atlas with right-click
         if (mouseState == 1 && state.is(NORMAL)) {
-            onClose();
+            close();
             return true;
         }
 
@@ -647,13 +647,13 @@ public class GuiAtlas extends GuiComponent {
         } else if (keyCode == GLFW.GLFW_KEY_MINUS || keyCode == GLFW.GLFW_KEY_KP_SUBTRACT) {
             setMapScale(mapScale / 2);
         } else if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
-            onClose();
+            close();
         } else {
-            KeyBinding[] hotbarKeys = MinecraftClient.getInstance().options.keysHotbar;
+            KeyBinding[] hotbarKeys = MinecraftClient.getInstance().options.hotbarKeys;
             for (KeyBinding bind : hotbarKeys) {
                 // only handle hotbarkeys when marker gui isn't shown1
                 if (bind.matchesKey(keyCode, scanCode) && this.markerFinalizer.getParent() == null) {
-                    onClose();
+                    close();
                     // if we close the gui, then don't handle the event
                     return false;
                 }
@@ -1159,14 +1159,14 @@ public class GuiAtlas extends GuiComponent {
     }
 
     @Override
-    public boolean isPauseScreen() {
+    public boolean shouldPause() {
         return false;
     }
 
     @Override
-    public void onClose() {
-        super.onClose();
-        markerFinalizer.close();
+    public void close() {
+        super.close();
+        markerFinalizer.closeChild();
         removeChild(blinkingIcon);
         // Keyboard.enableRepeatEvents(false);
         biomeData.setBrowsingPosition(mapOffsetX, mapOffsetY, mapScale);

--- a/src/main/java/hunternif/mc/impl/atlas/client/gui/GuiMarkerFinalizer.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/gui/GuiMarkerFinalizer.java
@@ -87,10 +87,10 @@ public class GuiMarkerFinalizer extends GuiComponent {
             world.playSound(player, player.getBlockPos(),
                     SoundEvents.ENTITY_VILLAGER_WORK_CARTOGRAPHER, SoundCategory.AMBIENT,
                     1F, 1F);
-            close();
+            closeChild();
         }));
         addDrawableChild(btnCancel = new ButtonWidget(this.width / 2 + BUTTON_SPACING / 2, this.height / 2 + 40, BUTTON_WIDTH, 20, new TranslatableText("gui.cancel"), (button) -> {
-            close();
+            closeChild();
         }));
         textField = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, (this.width - 200) / 2, this.height / 2 - 81, 200, 20, new TranslatableText("gui.antiqueatlas.marker.label"));
         textField.setEditable(true);
@@ -137,10 +137,10 @@ public class GuiMarkerFinalizer extends GuiComponent {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public void closeChild() {
+        super.closeChild();
         if (scroller != null) {
-            scroller.close();
+            scroller.closeChild();
         }
     }
 

--- a/src/main/java/hunternif/mc/impl/atlas/client/gui/core/GuiComponent.java
+++ b/src/main/java/hunternif/mc/impl/atlas/client/gui/core/GuiComponent.java
@@ -429,11 +429,11 @@ public class GuiComponent extends Screen {
      * Called when the GUI is unloaded, called for each child as well.
      */
     @Override
-    public void onClose() {
+    public void close() {
         for (GuiComponent child : children) {
-            child.onClose();
+            child.close();
         }
-        super.onClose();
+        super.close();
     }
 
     /**
@@ -621,7 +621,7 @@ public class GuiComponent extends Screen {
     /**
      * Remove itself from its parent component (if any), notifying it.
      */
-    public void close() {
+    public void closeChild() {
         if (parent != null) {
             parent.removeChild(this); // This sets parent to null
         } else {

--- a/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorBase.java
+++ b/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorBase.java
@@ -116,7 +116,7 @@ public class TileDetectorBase implements ITileDetector {
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 // biomes seems to be changing with height as well. Let's scan at sea level.
-                Biome biome = chunk.getBiomeForNoiseGen(x, world.getSeaLevel(), z);
+                Biome biome = chunk.getBiomeForNoiseGen(x, world.getSeaLevel(), z).value();
                 if (AntiqueAtlasMod.CONFIG.doScanPonds) {
                     int y = chunk.getHeightmap(Heightmap.Type.MOTION_BLOCKING).get(x, z);
                     if (y > 0) {

--- a/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorBase.java
+++ b/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorBase.java
@@ -145,7 +145,7 @@ public class TileDetectorBase implements ITileDetector {
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 // biomes seems to be changing with height as well. Let's scan at sea level.
-                Biome biome = chunk.getBiomeForNoiseGen(x, world.getSeaLevel(), z);
+                Biome biome = chunk.getBiomeForNoiseGen(x, world.getSeaLevel(), z).value();
 
                 // get top block
                 int y = chunk.getHeightmap(Heightmap.Type.MOTION_BLOCKING).get(x, z);

--- a/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorEnd.java
+++ b/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorEnd.java
@@ -29,7 +29,7 @@ public class TileDetectorEnd extends TileDetectorBase implements ITileDetector {
 
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
-                Biome biome = chunk.getBiomeForNoiseGen(x, 0, z);
+                Biome biome = chunk.getBiomeForNoiseGen(x, 0, z).value();
 
                 Identifier id = getBiomeIdentifier(world, biome);
 

--- a/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorNether.java
+++ b/src/main/java/hunternif/mc/impl/atlas/core/scaning/TileDetectorNether.java
@@ -43,7 +43,7 @@ public class TileDetectorNether extends TileDetectorBase implements ITileDetecto
 
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
-                Biome biome = chunk.getBiomeForNoiseGen(x, lavaSeaLevel, z);
+                Biome biome = chunk.getBiomeForNoiseGen(x, lavaSeaLevel, z).value();
                 if (biome.getCategory() == Biome.Category.NETHER) {
                     // The Nether!
                     Block seaLevelBlock = chunk.getBlockState(new BlockPos(x, lavaSeaLevel, z)).getBlock();

--- a/src/main/java/hunternif/mc/impl/atlas/mixin/prod/MixinCartographyTableHandlerSlot.java
+++ b/src/main/java/hunternif/mc/impl/atlas/mixin/prod/MixinCartographyTableHandlerSlot.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "net.minecraft.screen.CartographyTableScreenHandler$4")
 class MixinCartographyTableScreenHandlerSlot {
 
-    @Inject(method = "method_7680", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "canInsert", at = @At("RETURN"), cancellable = true)
     void antiqueatlas_canInsert(ItemStack stack, CallbackInfoReturnable<Boolean> info) {
         info.setReturnValue(stack.getItem() == AtlasAPI.getAtlasItem() || info.getReturnValueZ());
     }
@@ -32,7 +32,7 @@ class MixinCartographyTableScreenHandlerResultSlot {
         antiqueatlas_handler = handler;
     }
 
-    @Inject(method = "method_7667", at = @At("HEAD"))
+    @Inject(method = "onTakeItem", at = @At("HEAD"))
     void antiqueatlas_onTakeItem(PlayerEntity player, ItemStack atlas, CallbackInfo info) {
         if (atlas.getItem() == AtlasAPI.getAtlasItem()) {
             ItemStack map = antiqueatlas_handler.slots.get(0).getStack();

--- a/src/main/java/hunternif/mc/impl/atlas/mixin/structure/StructureStartMixin.java
+++ b/src/main/java/hunternif/mc/impl/atlas/mixin/structure/StructureStartMixin.java
@@ -57,7 +57,7 @@ public class StructureStartMixin {
         synchronized (this.children) {
             if(this.children.isEmpty()) return;
 
-            StructureAddedCallback.EVENT.invoker().onStructureAdded((StructureStart<?>) (Object) this, world);
+            StructureAddedCallback.EVENT.invoker().onStructureAdded((StructureStart) (Object) this, world);
         }
     }
 }

--- a/src/main/java/hunternif/mc/impl/atlas/registry/MarkerType.java
+++ b/src/main/java/hunternif/mc/impl/atlas/registry/MarkerType.java
@@ -28,7 +28,8 @@ public class MarkerType {
 	public static final RegistryKey<Registry<MarkerType>> KEY = RegistryKey.ofRegistry(AntiqueAtlasMod.id("marker"));
 	public static final DefaultedRegistry<MarkerType> REGISTRY = new DefaultedRegistry<>(AntiqueAtlasMod.id("red_x_small").toString(),
 			KEY,
-			Lifecycle.experimental());
+			Lifecycle.experimental(),
+			null);
 
 	private Identifier[] icons;
 	private BitMatrix[] iconPixels;

--- a/src/main/java/hunternif/mc/impl/atlas/structure/EndCity.java
+++ b/src/main/java/hunternif/mc/impl/atlas/structure/EndCity.java
@@ -7,7 +7,7 @@ import net.minecraft.world.gen.feature.StructureFeature;
 public class EndCity {
 
     public static void registerMarkers() {
-        StructureHandler.registerMarker(StructureFeature.END_CITY, AntiqueAtlasMod.id("end_city"), new LiteralText(""));
+        StructureHandler.registerMarker(StructureFeature.ENDCITY, AntiqueAtlasMod.id("end_city"), new LiteralText(""));
     }
 
 }

--- a/src/main/java/hunternif/mc/impl/atlas/structure/StructureAddedCallback.java
+++ b/src/main/java/hunternif/mc/impl/atlas/structure/StructureAddedCallback.java
@@ -14,5 +14,5 @@ public interface StructureAddedCallback {
 				}
 			});
 
-	void onStructureAdded(StructureStart<?> structureStart, ServerWorld world);
+	void onStructureAdded(StructureStart structureStart, ServerWorld world);
 }

--- a/src/main/java/hunternif/mc/impl/atlas/structure/StructureHandler.java
+++ b/src/main/java/hunternif/mc/impl/atlas/structure/StructureHandler.java
@@ -118,8 +118,8 @@ public class StructureHandler {
         }
     }
 
-    public static void resolve(StructureStart<?> structureStart, ServerWorld world) {
-        Identifier structureId = Registry.STRUCTURE_FEATURE.getId(structureStart.getFeature());
+    public static void resolve(StructureStart structureStart, ServerWorld world) {
+        Identifier structureId = Registry.STRUCTURE_FEATURE.getId(structureStart.getFeature().feature);
         if (STRUCTURE_PIECE_TO_MARKER_MAP.containsKey(structureId)) {
             Triple<Integer, Integer, Identifier> key = Triple.of(
                     structureStart.getBoundingBox().getCenter().getX(),

--- a/src/main/resources/antiqueatlas.accesswidener
+++ b/src/main/resources/antiqueatlas.accesswidener
@@ -1,3 +1,5 @@
 accessWidener v1 named
 accessible field net/minecraft/world/ChunkRegion world Lnet/minecraft/server/world/ServerWorld;
 accessible field net/minecraft/structure/pool/SinglePoolElement location Lcom/mojang/datafixers/util/Either;
+accessible method net/minecraft/world/biome/Biome getCategory (Lnet/minecraft/util/registry/RegistryEntry;)Lnet/minecraft/world/biome/Biome$Category;
+accessible method net/minecraft/world/biome/Biome getCategory ()Lnet/minecraft/world/biome/Biome$Category;

--- a/src/main/resources/antiqueatlas.mixins.json
+++ b/src/main/resources/antiqueatlas.mixins.json
@@ -14,7 +14,7 @@
     "dev.MixinCartographyTableScreenHandlerSlot",
     "prod.MixinCartographyTableScreenHandlerSlot",
     "dev.MixinCartographyTableScreenHandlerResultSlot",
-    "prod.MixinCartographyTableScreenHandlerResultSlot",
+    "prod.MixinCartographyTableScreenHandlerResultSlot"
   ],
   "client": [
     "MixinClientPlayNetworkHandler",


### PR DESCRIPTION
No fixes to the limitations of 1.18 antique atlas, just a version bump

![java_kyPQ4PAkPe](https://user-images.githubusercontent.com/55819817/182013398-6f47d500-e99b-4ae5-9515-11ebf6b7c5d9.png)

![image](https://user-images.githubusercontent.com/55819817/182013557-62425480-3a2a-41b7-91bb-dfe8efbf1c43.png)
 
Runs fine on fabric and quilt 1.18.2 with at least basic testing in all dimensions.

We personally don't care too much for the elevation of things being super accurate, we mostly like this mod for the limited visibility over map mods with color and per-block detail, so we ported this for us and figured we'd PR it for anyone else. Missing 1.18 biome textures is still an issue though (afaik)
