### PR TITLE
Fix resource loaders on Quilt (/stop yolo'ing it on fabric)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ run*
 
 classes
 logs
+
+.architectury-transformer

--- a/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
@@ -19,23 +19,27 @@ import net.minecraft.world.biome.Biome;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
 
 @Environment(EnvType.CLIENT)
 public class ClientProxy implements ResourceReloader {
+    public static BiConsumer<ResourceType, ResourceReloader> SORTED_REGISTER_LISTENER = ReloadListenerRegistry::register;
+
     public void initClient() {
+
         // read Textures first from assets
         TextureConfig textureConfig = new TextureConfig(Textures.TILE_TEXTURES_MAP);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureConfig);
+        SORTED_REGISTER_LISTENER.accept(ResourceType.CLIENT_RESOURCES, textureConfig);
 
         // then read TextureSets
         TextureSetMap textureSetMap = TextureSetMap.instance();
         TextureSetConfig textureSetConfig = new TextureSetConfig(textureSetMap);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureSetConfig);
+        SORTED_REGISTER_LISTENER.accept(ResourceType.CLIENT_RESOURCES, textureSetConfig);
 
         // After that, we can read the tile mappings
         TileTextureMap tileTextureMap = TileTextureMap.instance();
         TileTextureConfig tileTextureConfig = new TileTextureConfig(tileTextureMap, textureSetMap);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, tileTextureConfig);
+        SORTED_REGISTER_LISTENER.accept(ResourceType.CLIENT_RESOURCES, tileTextureConfig);
 
         // Legacy file name:
         ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, this);

--- a/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
@@ -93,6 +93,6 @@ public class ClientProxy implements ResourceReloader {
                 type.initMips();
             }
             assignBiomeTextures();
-        }));
+        }, applyExecutor));
     }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
@@ -54,7 +54,7 @@ public class TextureConfig implements IResourceReloadListener<Map<Identifier, IT
             }
 
             return textures;
-        });
+        }, executor);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class TextureConfig implements IResourceReloadListener<Map<Identifier, IT
                 texture_map.put(entry.getKey(), entry.getValue());
                 Log.info("Loaded texture %s with path %s", entry.getKey(), entry.getValue().getTexture());
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
@@ -115,7 +115,7 @@ public class TextureSetConfig implements IResourceReloadListener<Collection<Text
             }
 
             return sets.values();
-        });
+        }, executor);
     }
 
     @Override
@@ -142,7 +142,7 @@ public class TextureSetConfig implements IResourceReloadListener<Collection<Text
                     Log.info("Loaded water texture `%s` for shore texture `%s` texture", texture.waterName, texture.name);
                 }
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
@@ -92,7 +92,7 @@ public class TileTextureConfig implements IResourceReloadListener<Map<Identifier
             }
 
             return map;
-        });
+        }, executor);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class TileTextureConfig implements IResourceReloadListener<Map<Identifier
                 tileTextureMap.setTexture(entry.getKey(), set);
                 Log.info("Loaded tile %s with texture set %s", tile_id, set.name);
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
@@ -65,7 +65,7 @@ public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifi
             }
 
             return typeMap;
-        });
+        }, executor);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifi
             for (Map.Entry<Identifier, MarkerType> entry : data.entrySet()) {
                 MarkerType.register(entry.getKey(), entry.getValue());
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/ClientProxyMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/ClientProxyMixin.java
@@ -1,0 +1,18 @@
+package hunternif.mc.impl.atlas.mixin.fabric;
+
+import hunternif.mc.impl.atlas.ClientProxy;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.minecraft.resource.ResourceReloader;
+import net.minecraft.resource.ResourceType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.function.BiConsumer;
+
+@Mixin(ClientProxy.class)
+public class ClientProxyMixin {
+    // This doesn't REALLY need to be a mixin, but it's tidy and ensures it runs at the right time for some reason.
+    @Shadow
+    public static BiConsumer<ResourceType, ResourceReloader> SORTED_REGISTER_LISTENER = (t, r) -> ResourceManagerHelper.get(t).registerReloadListener((IdentifiableResourceReloadListener) r);
+}

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureConfigMixin.java
@@ -2,26 +2,18 @@ package hunternif.mc.impl.atlas.mixin.fabric;
 
 import hunternif.mc.impl.atlas.client.TextureConfig;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
-import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.profiler.Profiler;
 import org.spongepowered.asm.mixin.Mixin;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 @Mixin(TextureConfig.class)
-public class TextureConfigMixin implements IdentifiableResourceReloadListener {
+public abstract class TextureConfigMixin implements IdentifiableResourceReloadListener {
+
     @Override
     public Identifier getFabricId() {
         return new Identifier("antiqueatlas", "textures");
-    }
-
-    @Override
-    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
-        return null;
     }
 
     @Override

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureConfigMixin.java
@@ -1,0 +1,32 @@
+package hunternif.mc.impl.atlas.mixin.fabric;
+
+import hunternif.mc.impl.atlas.client.TextureConfig;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Mixin(TextureConfig.class)
+public class TextureConfigMixin implements IdentifiableResourceReloadListener {
+    @Override
+    public Identifier getFabricId() {
+        return new Identifier("antiqueatlas", "textures");
+    }
+
+    @Override
+    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
+        return null;
+    }
+
+    @Override
+    public Collection<Identifier> getFabricDependencies() {
+        return List.of(
+        );
+    }
+}

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureSetConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureSetConfigMixin.java
@@ -2,26 +2,18 @@ package hunternif.mc.impl.atlas.mixin.fabric;
 
 import hunternif.mc.impl.atlas.client.TextureSetConfig;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
-import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.profiler.Profiler;
 import org.spongepowered.asm.mixin.Mixin;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 @Mixin(TextureSetConfig.class)
-public class TextureSetConfigMixin implements IdentifiableResourceReloadListener {
+public abstract class TextureSetConfigMixin implements IdentifiableResourceReloadListener {
+
     @Override
     public Identifier getFabricId() {
         return new Identifier("antiqueatlas", "texture_sets");
-    }
-
-    @Override
-    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
-        return null;
     }
 
     @Override

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureSetConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TextureSetConfigMixin.java
@@ -1,0 +1,33 @@
+package hunternif.mc.impl.atlas.mixin.fabric;
+
+import hunternif.mc.impl.atlas.client.TextureSetConfig;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Mixin(TextureSetConfig.class)
+public class TextureSetConfigMixin implements IdentifiableResourceReloadListener {
+    @Override
+    public Identifier getFabricId() {
+        return new Identifier("antiqueatlas", "texture_sets");
+    }
+
+    @Override
+    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
+        return null;
+    }
+
+    @Override
+    public Collection<Identifier> getFabricDependencies() {
+        return List.of(
+                new Identifier("antiqueatlas", "textures")
+        );
+    }
+}

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TileTextureConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TileTextureConfigMixin.java
@@ -1,0 +1,35 @@
+package hunternif.mc.impl.atlas.mixin.fabric;
+
+import hunternif.mc.impl.atlas.client.TileTextureConfig;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Mixin(TileTextureConfig.class)
+public class TileTextureConfigMixin implements IdentifiableResourceReloadListener {
+
+    @Override
+    public Identifier getFabricId() {
+        return new Identifier("antiqueatlas", "tiles");
+    }
+
+    @Override
+    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
+        return null;
+    }
+
+    @Override
+    public Collection<Identifier> getFabricDependencies() {
+        return List.of(
+                new Identifier("antiqueatlas", "texture_sets"),
+                new Identifier("antiqueatlas", "textures")
+                );
+    }
+}

--- a/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TileTextureConfigMixin.java
+++ b/fabric/src/main/java/hunternif/mc/impl/atlas/mixin/fabric/TileTextureConfigMixin.java
@@ -2,27 +2,18 @@ package hunternif.mc.impl.atlas.mixin.fabric;
 
 import hunternif.mc.impl.atlas.client.TileTextureConfig;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
-import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.profiler.Profiler;
 import org.spongepowered.asm.mixin.Mixin;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 @Mixin(TileTextureConfig.class)
-public class TileTextureConfigMixin implements IdentifiableResourceReloadListener {
+public abstract class TileTextureConfigMixin implements IdentifiableResourceReloadListener {
 
     @Override
     public Identifier getFabricId() {
         return new Identifier("antiqueatlas", "tiles");
-    }
-
-    @Override
-    public CompletableFuture<Void> reload(Synchronizer synchronizer, ResourceManager manager, Profiler prepareProfiler, Profiler applyProfiler, Executor prepareExecutor, Executor applyExecutor) {
-        return null;
     }
 
     @Override

--- a/fabric/src/main/resources/antiqueatlas.mixins.json
+++ b/fabric/src/main/resources/antiqueatlas.mixins.json
@@ -5,6 +5,9 @@
   "mixins": [
   ],
   "client": [
+    "TextureConfigMixin",
+    "TextureSetConfigMixin",
+    "TileTextureConfigMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/src/main/resources/antiqueatlas.mixins.json
+++ b/fabric/src/main/resources/antiqueatlas.mixins.json
@@ -7,7 +7,8 @@
   "client": [
     "TextureConfigMixin",
     "TextureSetConfigMixin",
-    "TileTextureConfigMixin"
+    "TileTextureConfigMixin",
+    "ClientProxyMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Mixes in from the fabric side to make sure that Textures load before Texturesets which load before Tiles. Fixes #438.