### PR TITLE
Add IDs and Dependencies to ResourceListeners. Fix #438

### DIFF
--- a/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
@@ -25,23 +25,23 @@ public class ClientProxy implements ResourceReloader {
     public void initClient() {
         // read Textures first from assets
         TextureConfig textureConfig = new TextureConfig(Textures.TILE_TEXTURES_MAP);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureConfig);
+        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureConfig, textureConfig.getId(), textureConfig.getDependencies());
 
         // then read TextureSets
         TextureSetMap textureSetMap = TextureSetMap.instance();
         TextureSetConfig textureSetConfig = new TextureSetConfig(textureSetMap);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureSetConfig);
+        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, textureSetConfig, textureSetConfig.getId(), textureSetConfig.getDependencies());
 
         // After that, we can read the tile mappings
         TileTextureMap tileTextureMap = TileTextureMap.instance();
         TileTextureConfig tileTextureConfig = new TileTextureConfig(tileTextureMap, textureSetMap);
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, tileTextureConfig);
+        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, tileTextureConfig, tileTextureConfig.getId(), tileTextureConfig.getDependencies());
 
         // Legacy file name:
         ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, this);
 
         MarkerTextureConfig markerTextureConfig = new MarkerTextureConfig();
-        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, markerTextureConfig);
+        ReloadListenerRegistry.register(ResourceType.CLIENT_RESOURCES, markerTextureConfig, markerTextureConfig.getId(), markerTextureConfig.getDependencies());
 
         for (MarkerType type : MarkerType.REGISTRY) {
             type.initMips();

--- a/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/ClientProxy.java
@@ -93,6 +93,6 @@ public class ClientProxy implements ResourceReloader {
                 type.initMips();
             }
             assignBiomeTextures();
-        }));
+        }, applyExecutor));
     }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/IResourceReloadListener.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/IResourceReloadListener.java
@@ -2,8 +2,10 @@ package hunternif.mc.impl.atlas.client;
 
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceReloader;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -30,5 +32,9 @@ public interface IResourceReloadListener<T> extends ResourceReloader
         return load.thenCompose(synchronizer::whenPrepared)
                 .thenCompose(t -> apply(t, manager, applyProfiler, applyExecutor));
     }
+
+    Identifier getId();
+
+    Collection<Identifier> getDependencies();
 
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
@@ -11,6 +11,8 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
 import net.minecraft.util.profiler.Profiler;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -26,6 +28,7 @@ import java.util.concurrent.Executor;
  */
 @Environment(EnvType.CLIENT)
 public class TextureConfig implements IResourceReloadListener<Map<Identifier, ITexture>> {
+    public static final Identifier ID = AntiqueAtlasMod.id("textures");
     private final Map<Identifier, ITexture> texture_map;
 
     public TextureConfig(Map<Identifier, ITexture> texture_map) {
@@ -70,6 +73,16 @@ public class TextureConfig implements IResourceReloadListener<Map<Identifier, IT
 
     @Override
     public String getName() {
-        return AntiqueAtlasMod.id("textures").toString();
+        return ID.toString();
+    }
+
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public Collection<Identifier> getDependencies() {
+        return Collections.emptyList();
     }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureConfig.java
@@ -54,7 +54,7 @@ public class TextureConfig implements IResourceReloadListener<Map<Identifier, IT
             }
 
             return textures;
-        });
+        }, executor);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class TextureConfig implements IResourceReloadListener<Map<Identifier, IT
                 texture_map.put(entry.getKey(), entry.getValue());
                 Log.info("Loaded texture %s with path %s", entry.getKey(), entry.getValue().getTexture());
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executor;
  */
 @Environment(EnvType.CLIENT)
 public class TextureSetConfig implements IResourceReloadListener<Collection<TextureSet>> {
+    public static final Identifier ID = AntiqueAtlasMod.id("texture_sets");
     private static final int VERSION = 1;
     private static final JsonParser PARSER = new JsonParser();
     private final TextureSetMap textureSetMap;
@@ -147,12 +148,16 @@ public class TextureSetConfig implements IResourceReloadListener<Collection<Text
 
     @Override
     public String getName() {
-        return AntiqueAtlasMod.id("texture_sets").toString();
+        return ID.toString();
     }
 
-    // TODO Fix dependencies
-//    @Override
-//    public Collection<Identifier> getFabricDependencies() {
-//        return Collections.singleton(new Identifier("antiqueatlas:textures"));
-//    }
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public Collection<Identifier> getDependencies() {
+        return Collections.singleton(TextureConfig.ID);
+    }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TextureSetConfig.java
@@ -115,7 +115,7 @@ public class TextureSetConfig implements IResourceReloadListener<Collection<Text
             }
 
             return sets.values();
-        });
+        }, executor);
     }
 
     @Override
@@ -142,7 +142,7 @@ public class TextureSetConfig implements IResourceReloadListener<Collection<Text
                     Log.info("Loaded water texture `%s` for shore texture `%s` texture", texture.waterName, texture.name);
                 }
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
@@ -14,6 +14,8 @@ import net.minecraft.util.profiler.Profiler;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -27,6 +29,7 @@ import java.util.concurrent.Executor;
  */
 @Environment(EnvType.CLIENT)
 public class TileTextureConfig implements IResourceReloadListener<Map<Identifier, Identifier>> {
+    public static final Identifier ID = AntiqueAtlasMod.id("tile_textures");
     private final TileTextureMap tileTextureMap;
     private final TextureSetMap textureSetMap;
 
@@ -117,12 +120,16 @@ public class TileTextureConfig implements IResourceReloadListener<Map<Identifier
 
     @Override
     public String getName() {
-        return AntiqueAtlasMod.id("tile_textures").toString();
+        return ID.toString();
     }
 
-    // TODO Fix dependencies
-//    @Override
-//    public Collection<Identifier> getFabricDependencies() {
-//        return Collections.singleton(new Identifier("antiqueatlas:texture_sets"));
-//    }
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public Collection<Identifier> getDependencies() {
+        return Collections.singleton(TextureSetConfig.ID);
+    }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/client/TileTextureConfig.java
@@ -92,7 +92,7 @@ public class TileTextureConfig implements IResourceReloadListener<Map<Identifier
             }
 
             return map;
-        });
+        }, executor);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class TileTextureConfig implements IResourceReloadListener<Map<Identifier
                 tileTextureMap.setTexture(entry.getKey(), set);
                 Log.info("Loaded tile %s with texture set %s", tile_id, set.name);
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
@@ -14,6 +14,8 @@ import net.minecraft.util.profiler.Profiler;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -26,6 +28,7 @@ import java.util.concurrent.Executor;
  */
 @Environment(EnvType.CLIENT)
 public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifier, MarkerType>> {
+    public static final Identifier ID = AntiqueAtlasMod.id("markers");
     private static final int VERSION = 1;
     private static final JsonParser parser = new JsonParser();
 
@@ -79,6 +82,16 @@ public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifi
 
     @Override
     public String getName() {
-        return AntiqueAtlasMod.id("markers").toString();
+        return ID.toString();
+    }
+
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public Collection<Identifier> getDependencies() {
+        return Collections.emptyList();
     }
 }

--- a/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
+++ b/common/src/main/java/hunternif/mc/impl/atlas/marker/MarkerTextureConfig.java
@@ -65,7 +65,7 @@ public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifi
             }
 
             return typeMap;
-        });
+        }, executor);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class MarkerTextureConfig implements IResourceReloadListener<Map<Identifi
             for (Map.Entry<Identifier, MarkerType> entry : data.entrySet()) {
                 MarkerType.register(entry.getKey(), entry.getValue());
             }
-        });
+        }, executor);
     }
 
     @Override

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "fabric": ">=0.28.0",
     "minecraft": ">=1.18.2",
     "cloth-config2": [">=6.2.62", "<7.0.0"],
-    "architectury": ">=4.9.83"
+    "architectury": ">=4.10.86"
   },
   "mixins": [
     "antiqueatlas.mixins.json",

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -39,6 +39,6 @@ side="BOTH"
 [[dependencies.antiqueatlas]]
 modId = "architectury"
 mandatory = true
-versionRange = "[4.9.83,)"
+versionRange = "[4.10.86,)"
 ordering = "AFTER"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ maven_group 			= hunternif.mc.atlas
 archives_base_name 		= antiqueatlas
 
 # Dependencies
-architectury_version    = 4.9.83
+architectury_version    = 4.10.86
 cloth_config_version	= 6.4.90
 fabric_api_version      = 0.58.0+1.18.2
 mod_menu_version		= 3.2.3


### PR DESCRIPTION
Uses the new optional IDs and dependencies on architectury for resource reloaders.
Fixes #438 